### PR TITLE
GeneralHtmlSupport and FontBackgroundColor conflict

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { Bold, Italic } from "@ckeditor/ckeditor5-basic-styles";
 import { Essentials } from "@ckeditor/ckeditor5-essentials";
 import { Paragraph } from "@ckeditor/ckeditor5-paragraph";
 import { GeneralHtmlSupport } from "@ckeditor/ckeditor5-html-support";
+import { FontBackgroundColor } from "@ckeditor/ckeditor5-font";
 
 import CKEditorInspector from "@ckeditor/ckeditor5-inspector";
 
@@ -25,7 +26,14 @@ const App = () => {
 
   const config = useMemo(
     () => ({
-      plugins: [Paragraph, Bold, Italic, Essentials, GeneralHtmlSupport],
+      plugins: [
+        Paragraph,
+        Bold,
+        Italic,
+        Essentials,
+        FontBackgroundColor,
+        GeneralHtmlSupport,
+      ],
       toolbar: ["bold", "italic"],
       htmlSupport: {
         allow: [
@@ -35,8 +43,6 @@ const App = () => {
           },
         ],
       },
-      plugins: [Paragraph, Bold, Italic, Essentials],
-      toolbar: ["bold", "italic"],
     }),
     [],
   );

--- a/src/App.js
+++ b/src/App.js
@@ -4,11 +4,12 @@ import { ClassicEditor } from "@ckeditor/ckeditor5-editor-classic";
 import { Bold, Italic } from "@ckeditor/ckeditor5-basic-styles";
 import { Essentials } from "@ckeditor/ckeditor5-essentials";
 import { Paragraph } from "@ckeditor/ckeditor5-paragraph";
+import { GeneralHtmlSupport } from "@ckeditor/ckeditor5-html-support";
 
 import CKEditorInspector from "@ckeditor/ckeditor5-inspector";
 
 const initialContent = `
-  <h1>Hello world</h1>
+  <h1 style="background: coral">Hello world</h1>
 `;
 
 const App = () => {
@@ -24,8 +25,16 @@ const App = () => {
 
   const config = useMemo(
     () => ({
-      plugins: [Paragraph, Bold, Italic, Essentials],
+      plugins: [Paragraph, Bold, Italic, Essentials, GeneralHtmlSupport],
       toolbar: ["bold", "italic"],
+      htmlSupport: {
+        allow: [
+          {
+            name: "h1",
+            styles: ["background"],
+          },
+        ],
+      },
     }),
     [],
   );

--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,8 @@ const App = () => {
           },
         ],
       },
+      plugins: [Paragraph, Bold, Italic, Essentials],
+      toolbar: ["bold", "italic"],
     }),
     [],
   );


### PR DESCRIPTION
 On the branch [ssimonsen/general-html-support](https://github.com/sunesimonsen/ckeditor-bugs/tree/ssimonsen/general-html-support) the editor renders the background color for the heading:

<img width="918" alt="Screenshot 2024-01-25 at 10 49 58" src="https://github.com/sunesimonsen/ckeditor-bugs/assets/90802/3cfdffcb-6f1a-4eea-a106-b357d195fcb9">

But when the [BackgroundFontColor](https://ckeditor.com/docs/ckeditor5/41.0.0/features/font.html) plugin is added the background color is no longer rendered:

<img width="919" alt="Screenshot 2024-01-25 at 10 53 32" src="https://github.com/sunesimonsen/ckeditor-bugs/assets/90802/a774eac2-70d0-48f1-b378-2ec2001e0c32">

I tracked the problem do to [this line](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-font/src/fontbackgroundcolor/fontbackgroundcolorediting.ts#L105), when removed everything works again.